### PR TITLE
feat: add ollama_host configuration option for dynamic API endpoint

### DIFF
--- a/src/ai-sdk.ts
+++ b/src/ai-sdk.ts
@@ -6,6 +6,7 @@ import { createAnthropic } from "@ai-sdk/anthropic"
 import { createGoogleGenerativeAI } from "@ai-sdk/google"
 import { CliError } from "./error"
 import { copilot } from "./copilot"
+import { getOllamaHost } from "./ollama"
 
 const missingConfigError = (
   type: "openai" | "anthropic" | "gemini" | "groq",
@@ -17,7 +18,9 @@ const missingConfigError = (
 
 export const getSDKModel = async (modelId: string, config: Config) => {
   if (modelId.startsWith("ollama-")) {
-    return createOllama()
+    return createOllama({
+      baseURL: getOllamaHost(),
+    })
   }
 
   if (modelId.startsWith("claude-")) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -73,6 +73,10 @@ export const ConfigSchema = z.object({
     .string()
     .optional()
     .describe('Default to the "GROQ_API_KEY" environment variable'),
+  ollama_host: z
+    .string()
+    .optional()
+    .describe('Default to the "OLLAMA_HOST" environment variable'),
   commands: z.array(AICommandSchema).optional(),
 })
 

--- a/src/ollama.ts
+++ b/src/ollama.ts
@@ -1,10 +1,15 @@
 import { ModelInfo } from "./models"
 import { loadConfig } from "./config"
 
-export async function getOllamaModels() {
+export function getOllamaHost() {
   const config = loadConfig()
-  const ollamaHost = config.ollama_host || process.env.OLLAMA_HOST || 'http://127.0.0.1:11434'
-  const models: ModelInfo[] = await fetch(`${ollamaHost}/api/tags`)
+  const baseUrl = config.ollama_host || process.env.OLLAMA_HOST || 'http://127.0.0.1:11434'
+  return `${baseUrl}/api`
+}
+
+export async function getOllamaModels() {
+  const ollamaHost = getOllamaHost()
+  const models: ModelInfo[] = await fetch(`${ollamaHost}/tags`)
     .then((res) => {
       if (!res.ok) return []
 

--- a/src/ollama.ts
+++ b/src/ollama.ts
@@ -1,7 +1,10 @@
 import { ModelInfo } from "./models"
+import { loadConfig } from "./config"
 
 export async function getOllamaModels() {
-  const models: ModelInfo[] = await fetch(`http://127.0.0.1:11434/api/tags`)
+  const config = loadConfig()
+  const ollamaHost = config.ollama_host || process.env.OLLAMA_HOST || 'http://127.0.0.1:11434'
+  const models: ModelInfo[] = await fetch(`${ollamaHost}/api/tags`)
     .then((res) => {
       if (!res.ok) return []
 


### PR DESCRIPTION
# Improve Ollama Configuration and API Endpoint Handling

## Changes
- Enhanced configuration system for Ollama host settings
  - Added support for ollama_host in config files
  - Maintained environment variable support (OLLAMA_HOST)
  - Implemented fallback to default value (http://127.0.0.1:11434)
- Improved API endpoint handling
  - Centralized `/api` suffix handling in `getOllamaHost()`
  - Ensures consistent URL structure across all Ollama API calls
  - Updated model fetching to work with the new URL pattern

## Testing
1. Build and install locally:
```bash
pnpm install
pnpm build
```

2. Test with different configurations:
- Using config file (~/.config/shell-ask/config.json):
```json
{
  "ollama_host": "http://custom-host:11434"
}
```
- Using environment variable:
```bash
OLLAMA_HOST=http://custom-host:11434 ask ...
```
- Default fallback to http://127.0.0.1:11434
- Verify that `/api` is correctly appended in all cases
