### PR TITLE
feat: fix gemini 2.0 flash not working by update the gemini api url

### DIFF
--- a/src/ai-sdk.ts
+++ b/src/ai-sdk.ts
@@ -42,7 +42,7 @@ export const getSDKModel = async (modelId: string, config: Config) => {
     const apiUrl =
       config.gemini_api_url ||
       process.env.GEMINI_API_URL ||
-      "https://generativelanguage.googleapis.com/v1beta/models"
+      "https://generativelanguage.googleapis.com/v1beta/"
     return createGoogleGenerativeAI({
       apiKey,
       baseURL: apiUrl,


### PR DESCRIPTION
gemini 2.0 flash model not working because the default api url is outdated, so I update to the latest url